### PR TITLE
Add Blog for Engineering Managers resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ This will ensure you are spending your time on the most impactful things first!
 - [Become an Engineering Leader Everyone Wants to Work With](https://newsletter.eng-leadership.com/p/become-an-engineering-leader-everyone)
 - [Your Engineering Team Should Be Looking to Solve Customer Problems](https://newsletter.eng-leadership.com/p/your-engineering-team-should-be-looking)
 - [How to Ace Engineering Manager Interviews](https://newsletter.eng-leadership.com/p/how-to-ace-engineering-manager-interviews)
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers
 - [The State of Engineering Leadership in 2025](https://newsletter.eng-leadership.com/p/the-state-of-engineering-leadership)
 - [First Time in a Leading Position? This Is What to Do](https://newsletter.eng-leadership.com/p/first-time-in-a-leading-position)
 - [15 Productivity Hacks Every Engineer & Manager Should Know](https://newsletter.eng-leadership.com/p/15-productivity-hacks-every-engineer)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ This will ensure you are spending your time on the most impactful things first!
 - [Become an Engineering Leader Everyone Wants to Work With](https://newsletter.eng-leadership.com/p/become-an-engineering-leader-everyone)
 - [Your Engineering Team Should Be Looking to Solve Customer Problems](https://newsletter.eng-leadership.com/p/your-engineering-team-should-be-looking)
 - [How to Ace Engineering Manager Interviews](https://newsletter.eng-leadership.com/p/how-to-ace-engineering-manager-interviews)
-- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers
 - [The State of Engineering Leadership in 2025](https://newsletter.eng-leadership.com/p/the-state-of-engineering-leadership)
 - [First Time in a Leading Position? This Is What to Do](https://newsletter.eng-leadership.com/p/first-time-in-a-leading-position)
 - [15 Productivity Hacks Every Engineer & Manager Should Know](https://newsletter.eng-leadership.com/p/15-productivity-hacks-every-engineer)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This will ensure you are spending your time on the most impactful things first!
 - [Alex Ewerlöf Notes](https://blog.alexewerlof.com/) by Alex Ewerlöf
 - [Sudo Make Me a CTO](https://makemeacto.substack.com/) by Sergio Visinoni
 - [Programming Leadership - Marcus Blankenship](https://marcusblankenship.substack.com/) by Marcus Blankenship
+- [Blog for Engineering Managers](https://blog4ems.com) by Stephane Moreau
 - [Leadership Superpowers](https://gplead.com/newsletter) by Gregor Purdy
 
 **People to follow on LinkedIn**


### PR DESCRIPTION
## Add Blog for Engineering Managers

[Blog for Engineering Managers](https://blog4ems.com) - Practical guidance, templates, and resources for engineering managers. Weekly newsletter covering hiring, talent management, team execution, and leadership development. 50+ Notion templates and an Engineering Manager's Field Guide.